### PR TITLE
Fix wildwood doors drop

### DIFF
--- a/src/main/java/epicsquid/mysticallib/block/BlockButtonStoneBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockButtonStoneBase.java
@@ -89,6 +89,7 @@ public class BlockButtonStoneBase extends BlockButtonStone implements IBlock, IM
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isOpaqueCube(@Nonnull IBlockState state) {
     return isOpaque;
   }
@@ -98,6 +99,7 @@ public class BlockButtonStoneBase extends BlockButtonStone implements IBlock, IM
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isFullCube(@Nonnull IBlockState state) {
     return false;
   }
@@ -138,6 +140,7 @@ public class BlockButtonStoneBase extends BlockButtonStone implements IBlock, IM
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
   }

--- a/src/main/java/epicsquid/mysticallib/block/BlockButtonWoodBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockButtonWoodBase.java
@@ -88,6 +88,7 @@ public class BlockButtonWoodBase extends BlockButtonWood implements IBlock, IMod
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isOpaqueCube(@Nonnull IBlockState state) {
     return isOpaque;
   }
@@ -97,6 +98,7 @@ public class BlockButtonWoodBase extends BlockButtonWood implements IBlock, IMod
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isFullCube(@Nonnull IBlockState state) {
     return false;
   }
@@ -137,6 +139,7 @@ public class BlockButtonWoodBase extends BlockButtonWood implements IBlock, IMod
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
   }

--- a/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
@@ -1,9 +1,6 @@
 package epicsquid.mysticallib.block;
 
 import epicsquid.mysticallib.LibRegistry;
-import epicsquid.mysticallib.model.CustomModelBlock;
-import epicsquid.mysticallib.model.CustomModelLoader;
-import epicsquid.mysticallib.model.ICustomModeledObject;
 import epicsquid.mysticallib.model.IModeledObject;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDoor;
@@ -12,13 +9,11 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemDoor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -28,6 +23,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Random;
 
 @SuppressWarnings("deprecation")
 public class BlockDoorBase extends BlockDoor implements IBlock, IModeledObject {
@@ -142,9 +138,21 @@ public class BlockDoorBase extends BlockDoor implements IBlock, IModeledObject {
     return itemBlock;
   }
 
+  @Nonnull
   @Override
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
+  }
+
+  @Nonnull
+  @Override
+  public Item getItemDropped(IBlockState state, Random rand, int fortune) {
+    return this.itemBlock;
+  }
+
+  @Override
+  public int quantityDropped(Random random) {
+    return 1;
   }
 
   @Nonnull

--- a/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
@@ -8,6 +8,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemDoor;
 import net.minecraft.item.ItemStack;
@@ -145,9 +146,9 @@ public class BlockDoorBase extends BlockDoor implements IBlock, IModeledObject {
   }
 
   @Nonnull
-  @Override
-  public Item getItemDropped(IBlockState state, Random rand, int fortune) {
-    return this.itemBlock;
+  public Item getItemDropped(IBlockState state, Random rand, int fortune)
+  {
+    return state.getValue(HALF) == BlockDoor.EnumDoorHalf.UPPER ? Items.AIR : itemBlock;
   }
 
   @Override

--- a/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockDoorBase.java
@@ -146,6 +146,7 @@ public class BlockDoorBase extends BlockDoor implements IBlock, IModeledObject {
   }
 
   @Nonnull
+  @Override
   public Item getItemDropped(IBlockState state, Random rand, int fortune)
   {
     return state.getValue(HALF) == BlockDoor.EnumDoorHalf.UPPER ? Items.AIR : itemBlock;

--- a/src/main/java/epicsquid/mysticallib/block/BlockLadderBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockLadderBase.java
@@ -99,6 +99,7 @@ public class BlockLadderBase extends BlockLadder implements IBlock, IModeledObje
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
   }

--- a/src/main/java/epicsquid/mysticallib/block/BlockPressurePlateBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockPressurePlateBase.java
@@ -90,6 +90,7 @@ public class BlockPressurePlateBase extends BlockPressurePlate implements IBlock
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isOpaqueCube(@Nonnull IBlockState state) {
     return isOpaque;
   }
@@ -99,6 +100,7 @@ public class BlockPressurePlateBase extends BlockPressurePlate implements IBlock
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isFullCube(@Nonnull IBlockState state) {
     return false;
   }
@@ -139,6 +141,7 @@ public class BlockPressurePlateBase extends BlockPressurePlate implements IBlock
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
   }

--- a/src/main/java/epicsquid/mysticallib/block/BlockSaplingBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockSaplingBase.java
@@ -89,6 +89,7 @@ public class BlockSaplingBase extends BlockBush implements IBlock, IModeledObjec
 
   @Override
   @Nonnull
+  @SuppressWarnings("deprecation")
   public AxisAlignedBB getBoundingBox(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
     return box;
   }
@@ -124,6 +125,7 @@ public class BlockSaplingBase extends BlockBush implements IBlock, IModeledObjec
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isOpaqueCube(@Nonnull IBlockState state) {
     return isOpaque;
   }
@@ -133,6 +135,7 @@ public class BlockSaplingBase extends BlockBush implements IBlock, IModeledObjec
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isFullCube(@Nonnull IBlockState state) {
     return false;
   }
@@ -257,6 +260,7 @@ public class BlockSaplingBase extends BlockBush implements IBlock, IModeledObjec
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public IBlockState getStateFromMeta(int meta) {
     return this.getDefaultState().withProperty(BlockSapling.STAGE, meta);
   }

--- a/src/main/java/epicsquid/mysticallib/block/BlockTrapDoorBase.java
+++ b/src/main/java/epicsquid/mysticallib/block/BlockTrapDoorBase.java
@@ -96,6 +96,7 @@ public class BlockTrapDoorBase extends BlockTrapDoor implements IBlock, IModeled
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isOpaqueCube(@Nonnull IBlockState state) {
     return isOpaque;
   }
@@ -105,6 +106,7 @@ public class BlockTrapDoorBase extends BlockTrapDoor implements IBlock, IModeled
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean isFullCube(@Nonnull IBlockState state) {
     return false;
   }
@@ -139,6 +141,7 @@ public class BlockTrapDoorBase extends BlockTrapDoor implements IBlock, IModeled
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
     return new ItemStack(itemBlock);
   }


### PR DESCRIPTION
Fix 2 bugs:
- Wildwood doors that dropped oak doors
- Wildwood doors that gave duplicate drop when broken from the top piece