### PR TITLE
Fix badge github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # MysticalLib
 
 [![Discord](https://img.shields.io/discord/455383608773836801.svg?style=for-the-badge&logo=discord)](https://discord.gg/75aVV7C)
-[![](https://img.shields.io/github/contributors/EpicSquid/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/EpicSquid/MysticalLib/graphs/contributors)
-[![](https://img.shields.io/github/issues/EpicSquid/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/EpicSquid/MysticalLib/issues)
-[![](https://img.shields.io/github/issues-pr/EpicSquid/MysticalWorld.svg?style=for-the-badge&logo=github)](https://github.com/EpicSquid/MysticalLib/pulls)
-[![](https://img.shields.io/github/forks/EpicSquid/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/EpicSquid/MysticalLib/network/members)
-[![](https://img.shields.io/github/stars/EpicSquid/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/EpicSquid/MysticalLib/stargazers)
-[![](https://img.shields.io/github/license/EpicSquid/MysticalLib.svg?logo=github&style=for-the-badge)](https://github.com/EpicSquid/MysticalLib/blob/master/LICENSE)
+[![](https://img.shields.io/github/contributors/MysticMods/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/MysticMods/MysticalLib/graphs/contributors)
+[![](https://img.shields.io/github/issues/MysticMods/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/MysticMods/MysticalLib/issues)
+[![](https://img.shields.io/github/issues-pr/MysticMods/MysticalWorld.svg?style=for-the-badge&logo=github)](https://github.com/MysticMods/MysticalLib/pulls)
+[![](https://img.shields.io/github/forks/MysticMods/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/MysticMods/MysticalLib/network/members)
+[![](https://img.shields.io/github/stars/MysticMods/MysticalLib.svg?style=for-the-badge&logo=github)](https://github.com/MysticMods/MysticalLib/stargazers)
+[![](https://img.shields.io/github/license/MysticMods/MysticalLib.svg?logo=github&style=for-the-badge)](https://github.com/MysticMods/MysticalLib/blob/master/LICENSE)
 [![](https://img.shields.io/endpoint.svg?style=for-the-badge&url=https%3A%2F%2Fshieldsio-patreon.herokuapp.com%2Fepicsquid315)](https://patreon.com/epicsquid315)
 
 Library mod used by the Mystical Mods (Embers, Roots, Blockcraftery and more)


### PR DESCRIPTION
Self-explanatory - fixes up the badges so that they display info from MysticMods/MysticalLib instead of EpicSquid/MysticalLib